### PR TITLE
chore: Activate Tests and Linting in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1481,6 +1481,7 @@ workflows:
             - pnpm-monorepo
       - semgrep-scan
       - go-mod-download
+      - go-lint
       # - fuzz-golang:
       #     name: op-challenger-fuzz
       #     package_name: op-challenger


### PR DESCRIPTION
## Linear

Closes SPI-130

## Description
- Activates a subset of workflows and jobs in the existing OP circleci config. The goal is to activate jobs testing and linting Go and Solidity code.
- Comments out the majority of the steps in the circle ci config so that only the steps shown below are run.
- One run of this appears to use about 1000 Circle CI credits, so we may want to pare down this list further in future.

<img width="1151" alt="Screenshot 2024-09-15 at 01 02 23" src="https://github.com/user-attachments/assets/d1bf82b0-e7ef-48bb-bdb9-a5e1bead31a8">

