### PR TITLE
chore: slither workflow

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -1,32 +1,32 @@
-name: 'Slither Analysis'
+# name: 'Slither Analysis'
 
-on:
-  workflow_dispatch:
-  pull_request:
-  push:
-    branches:
-      - develop
+# on:
+#   workflow_dispatch:
+#   pull_request:
+#   push:
+#     branches:
+#       - develop
 
-jobs:
-  slither-analyze:
-    runs-on: ubuntu-latest
-    container:
-      image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.49.0
-    steps:
-      - uses: actions/checkout@v4
+# jobs:
+#   slither-analyze:
+#     runs-on: ubuntu-latest
+#     container:
+#       image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.49.0
+#     steps:
+#       - uses: actions/checkout@v4
 
-      - name: Run Slither
-        uses: crytic/slither-action@v0.4.0
-        id: slither
-        with:
-          target: packages/contracts-bedrock
-          slither-config: packages/contracts-bedrock/slither.config.json
-          fail-on: config
-          sarif: results.sarif
-          slither-args: --triage-database packages/contracts-bedrock/slither.db.json
+#       - name: Run Slither
+#         uses: crytic/slither-action@v0.4.0
+#         id: slither
+#         with:
+#           target: packages/contracts-bedrock
+#           slither-config: packages/contracts-bedrock/slither.config.json
+#           fail-on: config
+#           sarif: results.sarif
+#           slither-args: --triage-database packages/contracts-bedrock/slither.db.json
 
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
-        if: always()
-        with:
-          sarif_file: ${{ steps.slither.outputs.sarif }}
+#       - name: Upload SARIF file
+#         uses: github/codeql-action/upload-sarif@v3
+#         if: always()
+#         with:
+#           sarif_file: ${{ steps.slither.outputs.sarif }}


### PR DESCRIPTION
## Linear
Closes SPI-133

## Description
This PR deactivates the Slither workflow. It's used for vulnerability analysis in smart contracts, so we might actually want to keep it, in which case we'll need to make some upgrades to our github org to support Github Advanced Security [ref](https://docs.github.com/en/enterprise-cloud@latest/billing/managing-billing-for-github-advanced-security/setting-up-a-trial-of-github-advanced-security)

Since we're developing internally at the moment, I think it's probably fine to deactivate for now. Happy to upgrade our github account if we'd prefer to keep it.