### PR TITLE
feat(api): optimism_getElectionWinners

### DIFF
--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -238,6 +238,10 @@ func (s *l2VerifierBackend) OnUnsafeL2Payload(ctx context.Context, envelope *eth
 	return nil
 }
 
+func (s *l2VerifierBackend) GetElectionWinners(ctx context.Context, epoch uint64) ([]eth.ElectionWinner, error) {
+	return []eth.ElectionWinner{}, nil
+}
+
 func (s *L2Verifier) L2Finalized() eth.L2BlockRef {
 	return s.engine.Finalized()
 }

--- a/op-node/node/api.go
+++ b/op-node/node/api.go
@@ -34,6 +34,7 @@ type driverClient interface {
 	SequencerActive(context.Context) (bool, error)
 	OnUnsafeL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error
 	OverrideLeader(ctx context.Context) error
+	GetElectionWinners(ctx context.Context, epoch uint64) ([]eth.ElectionWinner, error)
 }
 
 type SafeDBReader interface {
@@ -172,4 +173,11 @@ func (n *nodeAPI) Version(ctx context.Context) (string, error) {
 	recordDur := n.m.RecordRPCServerRequest("optimism_version")
 	defer recordDur()
 	return version.Version + "-" + version.Meta, nil
+}
+
+func (n *nodeAPI) GetElectionWinners(ctx context.Context, epoch uint64) ([]eth.ElectionWinner, error) {
+	recordDur := n.m.RecordRPCServerRequest("optimism_getElectionWinners")
+	defer recordDur()
+
+	return n.dr.GetElectionWinners(ctx, epoch)
 }

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -227,6 +227,7 @@ func NewDriver(
 
 	syncDeriver := &SyncDeriver{
 		Derivation:     derivationPipeline,
+		Election:       elec,
 		SafeHeadNotifs: safeHeadListener,
 		CLSync:         clSync,
 		Engine:         ec,


### PR DESCRIPTION
# Linear
closes SPI-224

# Description

- Currently reuses the `optimism_` namespace, at a later date we can move this to a `based_` namespace, leaving it here for the sake of unblocking batcher work
- Accessing this API is exposed on a different port, on the devnets its localhost:7545 not localhost:9545, the same applies to all the `optimism_` endpoints.
- Takes in an `epoch` parameter and will return a list of winners