### PR TITLE
[WIP] Fix L2 reorgs

### DIFF
--- a/based.json
+++ b/based.json
@@ -122,7 +122,7 @@
     "devnetL1-template": {
       "l1ChainID": 900,
       "l2ChainID": 901,
-      "l2BlockTime": 2,
+      "l2BlockTime": 12,
       "maxSequencerDrift": 300,
       "sequencerWindowSize": 200,
       "channelTimeout": 120,

--- a/op-node/rollup/derive/deriver.go
+++ b/op-node/rollup/derive/deriver.go
@@ -72,6 +72,7 @@ type PipelineDeriver struct {
 
 	needAttributesConfirmation bool
 	electionWinners            []*eth.ElectionWinner
+	electionWinnersQueue       [][]*eth.ElectionWinner
 }
 
 func NewPipelineDeriver(ctx context.Context, pipeline *DerivationPipeline) *PipelineDeriver {
@@ -96,6 +97,12 @@ func (d *PipelineDeriver) OnEvent(ev event.Event) bool {
 			return true
 		}
 		d.pipeline.log.Trace("Derivation pipeline step", "onto_origin", d.pipeline.Origin())
+
+		if len(d.electionWinners) > 0 && d.electionWinners[len(d.electionWinners)-1].Time < x.PendingSafe.Time-12 {
+			d.electionWinners = d.electionWinnersQueue[0]
+			// TODO: doesn't it cause memory leak?
+			d.electionWinnersQueue = d.electionWinnersQueue[1:]
+		}
 
 		preOrigin := d.pipeline.Origin()
 		attrib, err := d.pipeline.Step(d.ctx, x.PendingSafe, d.electionWinners)
@@ -135,7 +142,12 @@ func (d *PipelineDeriver) OnEvent(ev event.Event) bool {
 	case ConfirmReceivedAttributesEvent:
 		d.needAttributesConfirmation = false
 	case rollup.ElectionWinnerEvent:
-		d.electionWinners = x.ElectionWinners
+		if len(d.electionWinners) == 0 {
+			d.pipeline.log.Info("Election winners empty, updating right away")
+			d.electionWinners = x.ElectionWinners
+		}
+
+		d.electionWinnersQueue = append(d.electionWinnersQueue, x.ElectionWinners)
 	default:
 		return false
 	}

--- a/op-node/rollup/election/election_deriver.go
+++ b/op-node/rollup/election/election_deriver.go
@@ -64,7 +64,7 @@ func (ed *ElectionDeriver) ProcessNewL1Block(l1Head eth.L1BlockRef) {
 
 	// We dont need to recalculate the winners as we already did it for this epoch
 	// If they are equal and its zero, then its the genesis epoch
-	if epoch < ed.lastEpoch || (epoch == ed.lastEpoch && epoch != 0) {
+	if epoch <= ed.lastEpoch || (epoch == ed.lastEpoch && epoch != 0) {
 		err := fmt.Errorf("epoch %d is not greater than the last epoch saved which was %d", epoch, ed.lastEpoch)
 		ed.emitter.Emit(rollup.ElectionErrorEvent{Err: err})
 		return

--- a/packages/contracts-bedrock/deploy-config/devnetL1-template.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1-template.json
@@ -1,7 +1,7 @@
 {
   "l1ChainID": 900,
   "l2ChainID": 901,
-  "l2BlockTime": 2,
+  "l2BlockTime": 12,
   "maxSequencerDrift": 300,
   "sequencerWindowSize": 200,
   "channelTimeout": 120,


### PR DESCRIPTION
Managed to run up to block 200 and no L2 reorgs appeared.

<img width="1326" alt="Screenshot 2024-11-19 at 12 16 06" src="https://github.com/user-attachments/assets/b800e9da-c2a7-4b3b-aa6a-1d294ca8c105">

## Changes
- fix l2 block time to 12 (1:1 correspondence to l1 blocks) 
- added `electionWinnersQueue` in the derivation driver. 

## Description
- `electionWinners` are updated once the last electionWinner timestamp is smaller than the `L1Block` in the info transaction. `electionWinner` updated in the system transaction corresponds to the past election winner - the one that won the election for the l1 block that is updated in the same transaction. This stays unchanged, but it's worth pointing out.
