### PR TITLE
fix: election winners outdating in data source

### DIFF
--- a/op-node/rollup/derive/blob_data_source.go
+++ b/op-node/rollup/derive/blob_data_source.go
@@ -135,17 +135,9 @@ func (ds *BlobDataSource) dataAndHashesFromTxs(txs []TxWithReceipt, config *Data
 	var hashes []eth.IndexedBlobHash
 	blobIndex := 0 // index of each blob in the block's blob sidecar
 	blockTime := ds.ref.Time
-	electionWinners := ds.electionProvider.GetElectionWinners()
-	var electionWinner *eth.ElectionWinner
+	electionWinner := ds.electionProvider.GetElectionWinner(blockTime)
 
-	for _, winner := range electionWinners {
-		if blockTime == winner.Time {
-			ds.log.Debug("Batch from election winner found", "winner", winner.Address)
-			electionWinner = winner
-			break
-		}
-	}
-	if electionWinner == nil {
+	if electionWinner == (eth.ElectionWinner{}) {
 		ds.log.Warn("No election winner found for block", "blockTime", blockTime)
 		return data, hashes
 	}

--- a/op-node/rollup/derive/blob_data_source_test.go
+++ b/op-node/rollup/derive/blob_data_source_test.go
@@ -21,12 +21,10 @@ type MockElectionWinnersProvider struct {
 	electionWinner common.Address
 }
 
-func (m *MockElectionWinnersProvider) GetElectionWinners() []*eth.ElectionWinner {
-	return []*eth.ElectionWinner{
-		{
-			Address: m.electionWinner,
-			Time:    0x499602D2,
-		},
+func (m *MockElectionWinnersProvider) GetElectionWinner(_timestamp uint64) eth.ElectionWinner {
+	return eth.ElectionWinner{
+		Address: m.electionWinner,
+		Time:    0x499602D2,
 	}
 }
 


### PR DESCRIPTION
The problem that was causing op-node not to finalise was the lack of electionWinners queue in data_source.go
<img width="768" alt="Screenshot 2024-12-17 at 09 26 08" src="https://github.com/user-attachments/assets/4dbbf4d6-7341-4f88-be86-bace591ed61d" />
